### PR TITLE
updated '== Summary' section added the word 'to'

### DIFF
--- a/1.quickstart/6.property-and-event-binding/index.adoc
+++ b/1.quickstart/6.property-and-event-binding/index.adoc
@@ -182,7 +182,7 @@ Now when we click the button, we set the show property to true which then _unhid
 
 == Summary
 
-The way think about these two different ways of binding is in terms of inputs and outputs.
+The way to think about these two different ways of binding is in terms of inputs and outputs.
 
 * With the `[]` we are binding to an input of a Component.
 * With the `()` we are binding to an output of a Component.


### PR DESCRIPTION
I made a small adjustment to the '== Summary' section by adding the word 'to'.

<Original Text>
"The way think about these two different ways of binding is in terms of inputs and outputs." 
- It is missing the word 'to' between 'The way' and 'think' at the start of the sentence

<After Update>
"The way to think about these two different ways of binding is in terms of inputs and outputs."