### PR TITLE
Updates `np-app` to `ng-app`

### DIFF
--- a/1.quickstart/3.first-app/index.adoc
+++ b/1.quickstart/3.first-app/index.adoc
@@ -122,7 +122,7 @@ We've defined a component with a custom tag, added the tag to our HTML but we ha
 
 To do that we need to do something called _bootstrapping_.
 
-TIP: In Angular 1 when we added `np-app=&quot;module-name&quot;` to the top of the HTML page it bootstrapped the application for us. When Angular 1 loaded it first checked for this tag, looked for the module that was associated with that tag and loaded the code from it. However with Angular we need to do all of this manually, for good reasons which we'll explain later.
+TIP: In Angular 1 when we added `ng-app=&quot;module-name&quot;` to the top of the HTML page it bootstrapped the application for us. When Angular 1 loaded it first checked for this tag, looked for the module that was associated with that tag and loaded the code from it. However with Angular we need to do all of this manually, for good reasons which we'll explain later.
 
 In Angular your code is structured into `packages` called Angular Modules, or `NgModules` for short. Every app requires at least one module, the root module, that we call `AppModule` by convention.
 


### PR DESCRIPTION
Fixes a typo in a Tip, from `np-app` to `ng-app`