### PR TITLE
Fix a typo

### DIFF
--- a/5.built-in-directives/6.structural-directives/index.adoc
+++ b/5.built-in-directives/6.structural-directives/index.adoc
@@ -54,7 +54,7 @@ The `NgFor` version is slightly more complex:
 
 == Syntax sugar and `*`
 
-So if we can write `ngIf` with `ng-template` what is al the fuss about `*`.
+So if we can write `ngIf` with `ng-template` what is all the fuss about `*`.
 
 When we _prepend_ a directive with `*` we are telling it to use the element it's attached to _as_ the template.
 


### PR DESCRIPTION
From "what is al the fuss about" To "what is all the fuss about"