### PR TITLE
Corrected typo

### DIFF
--- a/14.advanced-topics/1.basic-custom-validators/index.adoc
+++ b/14.advanced-topics/1.basic-custom-validators/index.adoc
@@ -108,7 +108,7 @@ Just like other validators lets add a helpful message to the user if the validat
 <div class="form-control-feedback"
      *ngIf="email.errors && (email.dirty || email.touched)">
   <p *ngIf="email.errors.required">Email is required</p>
-  <p *ngIf="password.errors.pattern">The email address must contain at least the @ character</p>
+  <p *ngIf="email.errors.pattern">The email address must contain at least the @ character</p>
   <p *ngIf="email.errors.emailDomain">Email must be on the codecraft.tv domain</p> # <1>
 </div>
 ----


### PR DESCRIPTION
One of the error validation messages was checking the errors for a "password" formcontrol, when it was supposed to be the email formcontrol like everything else.