### PR TITLE
Fixes NgIf wording

### DIFF
--- a/5.built-in-directives/3.ngif-and-ngswitch/index.adoc
+++ b/5.built-in-directives/3.ngif-and-ngswitch/index.adoc
@@ -68,7 +68,7 @@ class NgIfExampleComponent {
   ];
 }
 ----
-<1> The `NgIf` directive _removes_ the `li` element from the DOM if `person.age` is less than 30.
+<1> The `NgIf` directive _removes_ the `li` element from the DOM if `person.age` is greater than or equal to 30.
 
 If we ran the above we would see:
 


### PR DESCRIPTION
NgIf removes the DOM element if the NgIf condition is **not** met. The current wording states the DOM element is removed if the NgIf condition is met.