### PR TITLE
Update index.adoc

### DIFF
--- a/11.HTTP/3.http-with-promises/index.adoc
+++ b/11.HTTP/3.http-with-promises/index.adoc
@@ -426,7 +426,7 @@ export class SearchService {
 
 The results property is now an array of `SearchItems`.
 
-The names of the properties on our model have also changed, for instance `trackName` in the raw JSON returned from iTunes is now `track` on our `SearchItem` so we need to change our template bindings to match, like so:
+The names of the properties on our model have also changed, for instance `trackName` in the raw JSON returned from iTunes is now `name` on our `SearchItem` so we need to change our template bindings to match, like so:
 
 [source,html]
 ----


### PR DESCRIPTION
The property `track` is explained as `name` in the video and the code sample in the explanation text below.

Also, the **Listing** code at the end of the page needs to be edit to contain the `name` property instead of `track` in the *domain model* for better consistency.