### PR TITLE
fix(116): pipe bad words

### DIFF
--- a/8.pipes/7.activity/code/@solution/src/main.ts
+++ b/8.pipes/7.activity/code/@solution/src/main.ts
@@ -1,6 +1,6 @@
-import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
-import {Component, NgModule, Input, Output, EventEmitter, Pipe} from '@angular/core';
-import {BrowserModule} from '@angular/platform-browser';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { Component, NgModule, Input, Output, EventEmitter, Pipe } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
 
 @Pipe({
   name: "clean"
@@ -10,7 +10,8 @@ class CleanPipe {
     let badWordsList = badWords.split(',').map((item) => item.trim());
     console.log(badWordsList);
     for (let badWord of badWordsList) {
-      value = value.replace(badWord, "$%#@!")
+      const regex = new RegExp(badWord, "g");
+      value = value.replace(regex, "$%#@!");
     }
     return value;
   }


### PR DESCRIPTION
https://github.com/codecraft-tv/angular-course/issues/116

Addressing an issue where a bad word replacement Pipe was only replacing the first instance of a given bad word.  If the bad word was used more than once, the pipe wouldn't replace the subsequent use cases.

Fix: Added regex to make sure that it globally replaces the word and not just on the first occurrence.