### PR TITLE
Grammarly fix

### DIFF
--- a/2.es6-typescript/1.overview/index.adoc
+++ b/2.es6-typescript/1.overview/index.adoc
@@ -30,4 +30,4 @@ IMPORTANT: We should be using at least node version 6 to support most of the ES6
 
 TypeScript transpiles down into ES5 so we don't need to worry about browser support.
 
-Code will be provided for all the examples, but also we'll explain how to how to compile TypeScript locally on your computer with the command-line tools.
+Code will be provided for all the examples, but also we'll explain how to compile TypeScript locally on your computer with the command-line tools.


### PR DESCRIPTION
"we'll explain how to how to compile" should be "we'll explain how to compile"